### PR TITLE
Set git attribute default eol lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*     text=auto eol=lf


### PR DESCRIPTION
[Local.kt:133](https://github.com/JingMatrix/ChromeXt/blob/master/app/src/main/java/org/matrix/chromext/script/Local.kt#L133) split by `\n\n`.
App build on Windows will crash because when clone repository git converted `app/src/main/assets/scripts.js` to CRLF (\r\n) if `core.autocrlf==true|input`
-> [Local.kt:146](https://github.com/JingMatrix/ChromeXt/blob/master/app/src/main/java/org/matrix/chromext/script/Local.kt#L146) out of index range