### PR TITLE
Fix PageMenu NPE on table Chrome

### DIFF
--- a/app/src/main/java/org/matrix/chromext/hook/PageMenu.kt
+++ b/app/src/main/java/org/matrix/chromext/hook/PageMenu.kt
@@ -340,6 +340,7 @@ object PageMenuHook : BaseHook() {
               iconModels.entries
                   .find { it.key.toString() == "ADDITIONAL_ICONS" }
                   ?.let {
+                    it.value ?: return@let null
                     val _value = it.value!!::class.java.declaredFields[0]
                     _value.get(it.value)
                   }


### PR DESCRIPTION
Fix PageMenu NPE on table Chrome which have no ADDITIONAL_ICONS

but so it miss the ~~reader mode~~ page info tigger